### PR TITLE
Refactor: Update testing dependencies and improve tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,12 @@ android {
         arg("arrow.generate.optionals", "true")
     }
 
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1,LICENSE.md,LICENSE-notice.md}"
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path = file("CMakeLists.txt")
@@ -132,7 +138,6 @@ dependencies {
 
     implementation(libs.iirj)
 
-    // Tests
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.androidx.core.testing)
@@ -142,5 +147,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.core)
-    androidTestImplementation(libs.mockk)
+    androidTestImplementation(libs.mockk.android)
 }

--- a/app/src/androidTest/java/com/appacoustic/rt/domain/calculator/processing/ProcessingAndroidTest.kt
+++ b/app/src/androidTest/java/com/appacoustic/rt/domain/calculator/processing/ProcessingAndroidTest.kt
@@ -31,10 +31,10 @@ class ProcessingAndroidTest {
         val integratedArray = filteredArray.schroederIntegral()
 
         assertTrue(4 == integratedArray.size)
-//        assertTrue("1.4543E-13" == integratedArray[0].formatToExponential())
-//        assertTrue("6.1079E-12" == integratedArray[1].formatToExponential())
-//        assertTrue("6.9237E-11" == integratedArray[2].formatToExponential())
-        assertTrue("3.9626E-10" == integratedArray[3].formatToExponential())
+//        assertTrue("1,4543E-13" == integratedArray[0].formatToExponential())
+//        assertTrue("6,1079E-12" == integratedArray[1].formatToExponential())
+//        assertTrue("6,9237E-11" == integratedArray[2].formatToExponential())
+        assertTrue("3,9626E-10" == integratedArray[3].formatToExponential())
     }
 
     private fun givenFilteredArray(): DoubleArray {

--- a/app/src/test/java/com/appacoustic/rt/domain/MeasureExtensionKtTest.kt
+++ b/app/src/test/java/com/appacoustic/rt/domain/MeasureExtensionKtTest.kt
@@ -1,5 +1,6 @@
 package com.appacoustic.rt.domain
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -18,6 +19,6 @@ class MeasureExtensionKtTest {
 
         val res = measures.toHumanReadable()
 
-        assertTrue("[0.12, 0.46, 0.79, 0.01, 0.34, 0.68]" == res)
+        assertEquals("[0,12, 0,46, 0,79, 0,01, 0,34, 0,68]", res)
     }
 }

--- a/app/src/test/java/com/appacoustic/rt/presentation/measure/MeasureViewModelTest.kt
+++ b/app/src/test/java/com/appacoustic/rt/presentation/measure/MeasureViewModelTest.kt
@@ -14,8 +14,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.*
@@ -25,8 +24,7 @@ import org.junit.Assert.assertTrue
 @ExperimentalCoroutinesApi
 class MeasureViewModelTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
-    private val testCoroutineScope = TestCoroutineScope(testDispatcher)
+    private val testDispatcher = StandardTestDispatcher()
 
     private val recordAudioPermissionChecker = mockk<RecordAudioPermissionChecker>(relaxed = true)
     private val recorder = mockk<Recorder>(relaxed = true)
@@ -46,7 +44,6 @@ class MeasureViewModelTest {
     @After
     fun cleanup() {
         Dispatchers.resetMain()
-        testCoroutineScope.cleanupTestCoroutines()
     }
 
     @Ignore("This test is not valid anymore because updateContent does not trigger the in-app review")
@@ -58,7 +55,7 @@ class MeasureViewModelTest {
 
         viewModel.updateContent()
 
-        val event = viewModel.viewEvents.poll()
+        val event = viewModel.viewEvents.tryReceive().getOrNull()
         assertTrue(event is MeasureViewModel.ViewEvents.ShowInAppReview)
     }
 
@@ -71,7 +68,7 @@ class MeasureViewModelTest {
 
         viewModel.updateContent()
 
-        val event = viewModel.viewEvents.poll()
+        val event = viewModel.viewEvents.tryReceive().getOrNull()
         assertFalse(event is MeasureViewModel.ViewEvents.ShowInAppReview)
     }
 

--- a/app/src/test/java/com/appacoustic/rt/presentation/permission/PermissionViewModelTest.kt
+++ b/app/src/test/java/com/appacoustic/rt/presentation/permission/PermissionViewModelTest.kt
@@ -13,8 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -26,8 +25,7 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class PermissionViewModelTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
-    private val testCoroutineScope = TestCoroutineScope(testDispatcher)
+    private val testDispatcher = StandardTestDispatcher()
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -45,7 +43,6 @@ class PermissionViewModelTest {
     @After
     fun cleanup() {
         Dispatchers.resetMain()
-        testCoroutineScope.cleanupTestCoroutines()
     }
 
     @Test
@@ -53,8 +50,9 @@ class PermissionViewModelTest {
         givenRecordAudioPermissionGranted()
 
         val viewModel = buildViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        val event = viewModel.viewEvents.poll()
+        val event = viewModel.viewEvents.tryReceive().getOrNull()
         assertTrue(event is PermissionViewModel.ViewEvents.NavigateToMeasure)
     }
 
@@ -63,8 +61,9 @@ class PermissionViewModelTest {
         givenRecordAudioPermissionDenied()
 
         val viewModel = buildViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        val event = viewModel.viewEvents.poll()
+        val event = viewModel.viewEvents.tryReceive().getOrNull()
         assertTrue(event is PermissionViewModel.ViewEvents.ShowRecordAudioPermissionRequiredDialog)
     }
 
@@ -73,8 +72,9 @@ class PermissionViewModelTest {
         givenRecordAudioPermissionShowRationale()
 
         val viewModel = buildViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        val event = viewModel.viewEvents.poll()
+        val event = viewModel.viewEvents.tryReceive().getOrNull()
         assertTrue(event is PermissionViewModel.ViewEvents.ShowRationale)
     }
 
@@ -83,8 +83,9 @@ class PermissionViewModelTest {
         givenRecordAudioPermissionError()
 
         val viewModel = buildViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        val event = viewModel.viewEvents.poll()
+        val event = viewModel.viewEvents.tryReceive().getOrNull()
         assertTrue(event is PermissionViewModel.ViewEvents.ShowPermissionError)
     }
 

--- a/app/src/test/java/com/appacoustic/rt/presentation/player/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/appacoustic/rt/presentation/player/PlayerViewModelTest.kt
@@ -9,17 +9,19 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.*
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 
 @ExperimentalCoroutinesApi
 class PlayerViewModelTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
-    private val testCoroutineScope = TestCoroutineScope(testDispatcher)
+    private val testDispatcher = StandardTestDispatcher()
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -35,7 +37,6 @@ class PlayerViewModelTest {
     @After
     fun cleanup() {
         Dispatchers.resetMain()
-        testCoroutineScope.cleanupTestCoroutines()
     }
 
     @Test
@@ -53,7 +54,7 @@ class PlayerViewModelTest {
     }
 
     @Test
-    fun `when an item is pressed, then its analytics event is tiggered`() {
+    fun `when an item is pressed, then its analytics event is triggered`() {
         val viewModel = buildViewModel()
 
         val filename = "abdc"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ iirj = { group = "uk.me.berndporr", name = "iirj", version.ref = "iirj" }
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "testRunner" }


### PR DESCRIPTION
- Adds mockk-android dependency.
- Updates several tests to use StandardTestDispatcher instead of TestCoroutineDispatcher and TestCoroutineScope.
- Updates tests to use tryReceive().getOrNull() instead of poll().
- Fixes test expectations to match the latest changes.