### PR TITLE
WIP: Fix dlopen failed: library "libapi-keys.so" not found

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -38,7 +38,7 @@ find_library( # Sets the name of the path variable.
 
 target_link_libraries( # Specifies the target library.
         api-keys
-
+        android
         # Links the target library to the log library
         # included in the NDK.
         ${log-lib})

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
-
 android {
 
     val properties = Properties().apply {
@@ -48,7 +47,7 @@ android {
             enableSplit = true
         }
         abi {
-            enableSplit = true
+            enableSplit = false
         }
         language {
             enableSplit = false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,12 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.appacoustic.rt">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:name=".App"
         android:allowBackup="true"
+        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
@@ -20,15 +21,15 @@
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Splash">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
             android:name=".presentation.main.MainActivity"
-            android:screenOrientation="portrait"/>
+            android:screenOrientation="portrait" />
         <activity
             android:name=".presentation.authentication.AuthenticationActivity"
-            android:screenOrientation="portrait"/>
+            android:screenOrientation="portrait" />
     </application>
 </manifest>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 # Build Tools
-agp = "8.9.1"
+agp = "8.9.2"
 
 # Kotlin & Language Tools
-kotlin = "2.1.10"
-ksp = "2.1.10-1.0.29"
+kotlin = "2.1.20"
+ksp = "2.1.20-1.0.31"
 coroutinesCore = "1.10.1"
 coroutinesAndroid = "1.10.1"
 coroutinesTest = "1.10.1"
@@ -14,7 +14,7 @@ activity = "1.10.1"
 appcompat = "1.7.0"
 constraintlayout = "2.2.1"
 coreKtx = "1.16.0"
-lifecycle = "2.8.7"
+lifecycle = "2.9.0"
 material = "1.12.0"
 browser = "1.8.0"
 
@@ -22,7 +22,7 @@ browser = "1.8.0"
 koin = "2.2.2"
 
 # Firebase
-firebaseBom = "33.12.0"
+firebaseBom = "33.13.0"
 firebase-crashlytics = "3.0.3"
 google-services = "4.4.2"
 
@@ -30,11 +30,11 @@ google-services = "4.4.2"
 arrowCore = "1.2.0"
 
 # Room
-room = "2.7.0"
+room = "2.7.1"
 
 # External Libraries
 amplitude = "3.35.1"
-dexter = "6.2.1"
+dexter = "6.2.3"
 gson = "2.11.0"
 lottie = "3.4.2"
 mpandroidchart = "v3.1.0"


### PR DESCRIPTION
- Add `android:extractNativeLibs="true"` to the application tag in the Manifest.
- Update various dependencies to newer versions, including AGP, Kotlin, KSP, Lifecycle, Firebase, Room, and Dexter.
- Modify CMakeLists.txt to link the `android` library.
- Disable abi split in the build.gradle.kts file.